### PR TITLE
iOS versions compatibility fix

### DIFF
--- a/Sources/SwiftletModel/Index/Index+Comparable.swift
+++ b/Sources/SwiftletModel/Index/Index+Comparable.swift
@@ -8,7 +8,6 @@
 import Foundation
 import BTree
 import Collections
-import os
 
 extension Index {
     @EntityRefModel
@@ -17,7 +16,7 @@ extension Index {
         var id: String { name }
 
         let name: String
-        private let lock = OSAllocatedUnfairLock()
+        private let lock = NSLock()
         private var index: Map<Value, OrderedSet<Entity.ID>> = [:]
         private var indexedValues: [Entity.ID: Value] = [:]
 


### PR DESCRIPTION
PR fix compatibility with older iOS versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace OSAllocatedUnfairLock with NSLock in Index.ComparableValue to maintain compatibility with older iOS versions.
> 
> - **Model/Index**:
>   - Replace `OSAllocatedUnfairLock` with `NSLock` in `Index.ComparableValue` for wider iOS compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7636e2447bd10f7c613773a361d962cb40ce5c8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->